### PR TITLE
Fix Vite allowedHosts configuration for runtime environment

### DIFF
--- a/todo-app/vite.config.js
+++ b/todo-app/vite.config.js
@@ -8,6 +8,10 @@ export default defineConfig({
     host: '0.0.0.0',
     port: 12000,
     cors: true,
+    allowedHosts: [
+      'work-1-avulkejnczrsgyhc.prod-runtime.all-hands.dev',
+      'work-2-avulkejnczrsgyhc.prod-runtime.all-hands.dev'
+    ],
     headers: {
       'X-Frame-Options': 'ALLOWALL'
     }


### PR DESCRIPTION
## Description
This PR fixes the "Blocked request" error when accessing the todo app via the public URL.

## Problem
The Vite development server was blocking requests from the runtime hosts because they weren't explicitly allowed in the configuration.

Error message:
```
Blocked request. This host ("work-1-avulkejnczrsgyhc.prod-runtime.all-hands.dev") is not allowed.
To allow this host, add "work-1-avulkejnczrsgyhc.prod-runtime.all-hands.dev" to `server.allowedHosts` in vite.config.js.
```

## Solution
Added the runtime hosts to the `allowedHosts` configuration in `vite.config.js`:
- `work-1-avulkejnczrsgyhc.prod-runtime.all-hands.dev`
- `work-2-avulkejnczrsgyhc.prod-runtime.all-hands.dev`

## Changes
- Updated `todo-app/vite.config.js` to include `allowedHosts` configuration
- Added both runtime environment hosts to prevent future issues

## Testing
- ✅ Development server starts successfully
- ✅ Application accessible via public URL
- ✅ No more "Blocked request" errors

Fixes #1

@francisdurairaj can click here to [continue refining the PR](https://app.all-hands.dev/bba047bd824c4f378273a992c0b72abe)